### PR TITLE
Quickly finish refreshing.

### DIFF
--- a/circlerefresh/src/main/java/com/tuesda/walker/circlerefresh/AnimationView.java
+++ b/circlerefresh/src/main/java/com/tuesda/walker/circlerefresh/AnimationView.java
@@ -296,6 +296,8 @@ public class AnimationView extends View {
     private boolean mIsStart = true;
     private boolean mIsRefreshing = true;
 
+    private boolean isQuickStop = false;
+
     private void drawRefreshing(Canvas canvas) {
         canvas.drawRect(0, 0, mWidth, mHeight, mBackPaint);
         int innerY = PULL_HEIGHT - PULL_DELTA / 2 - mRadius * 2;
@@ -322,11 +324,17 @@ public class AnimationView extends View {
 
         }
 
+        if (isQuickStop){
+            mIsRefreshing = false;
+            isQuickStop = false;
+        }
     }
 
     // stop refreshing
     public void setRefreshing(boolean isFresh) {
-        mIsRefreshing = isFresh;
+
+            mIsRefreshing = isFresh;
+            isQuickStop = true;
     }
 
     private void drawDone(Canvas canvas) {


### PR DESCRIPTION
If the user stops the freshing by `CircleRefreshLayout.finishRefreshing()` immediately after the refresh starts, the method `AnimationView.startOutCir()` will run after that and will reset the boolean `AnimationView.mIsRefreshing` as true again. Then the refreshing drawing will never stop. 
In this pr, the problem can be solved and make no damage to the animation effect.
